### PR TITLE
Changed the docker images labels and name

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -11,11 +11,11 @@ pipeline {
     }
 
     environment {
-        NAME = "hms-bss"
+        NAME = "cray-bss"
         DESCRIPTION = "This is the location for the HMS Level 2 boot script service "
         IS_STABLE = getBuildIsStable()
         VERSION = getDockerBuildVersion(isStable: env.IS_STABLE)
-        DOCKER_ARGS = getDockerBuildArgs(name: env.NAME, description: env.DESCRIPTION)
+        DOCKER_ARGS = getDockerBuildArgs(name: "hms-bss", description: env.DESCRIPTION, version: env.VERSION)
     }
 
     stages {


### PR DESCRIPTION
This is a pull request that if accepted will be merged into feature/github (not into master)
DST build produces a docker image with the name cray-bss and the following labels:
```
{
  "com.jfrog.artifactory.retention.maxCount": "10",
  "maintainer": "Hewlett Packard Enterprise",
  "org.label-schema.description": "Cray boot script service",
  "org.label-schema.name": "hms-bss",
  "org.label-schema.schema-version": "1.0",
  "org.label-schema.url": "http://www.cray.com/",
  "org.label-schema.vcs-url": "https://stash.us.cray.com/scm/HMS/hms-bss.git",
  "org.label-schema.vendor": "Cray Inc",
  "org.label-schema.version": "1.9.3-20210714144339_bc330f8"
}
```

The old github changes produced an image named hms-bss, with these labels:
```
{
  "maintainer": "Cray, Inc.",
  "org.label-schema.description": "This is the location for the HMS Level 2 boot script service ",
  "org.label-schema.name": "hms-bss",
  "org.label-schema.schema-version": "1.0",
  "org.label-schema.url": "http://www.cray.com/",
  "org.label-schema.vcs-url": "https://github.com/Cray-HPE/hms-bss.git",
  "org.label-schema.vendor": "Cray Inc",
  "org.label-schema.version": "null"
}
```

With this PR it produces one with the name cray-bss
```
{
  "maintainer": "Cray, Inc.",
  "org.label-schema.description": "This is the location for the HMS Level 2 boot script service ",
  "org.label-schema.name": "hms-bss",
  "org.label-schema.schema-version": "1.0",
  "org.label-schema.url": "http://www.cray.com/",
  "org.label-schema.vcs-url": "https://github.com/Cray-HPE/hms-bss.git",
  "org.label-schema.vendor": "Cray Inc",
  "org.label-schema.version": "1.9.1-20210722164150_3353b71"
}
```




