### PR TITLE
CASMHMS-5608 Update internal HMS documentation for Helm CT tests

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-(C) Copyright [2021] Hewlett Packard Enterprise Development LP
+(C) Copyright [2021-2022] Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-(C) Copyright [2021-2022] Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
-This is the location for the HMS Level 2 boot script service code.
+This is the repository for the HMS Boot Script Service (BSS) code.
 
-It should include a Swagger.yaml or .json file for the service REST API,
-along with all of the code to implement the stateless service itself.
+It includes a swagger.yaml file for the service REST API specification, along with all of the code to implement the stateless
+service itself.
 
-This service should contain just what is needed to provide boot arguments (initrd, kargs, etc) Level 2 boot services for static 
-images.
+This service should contain just what is needed to provide boot arguments (initrd, kargs, etc) and Level 2 boot services for
+static images.
 
-This code will be refactored from the old hms-netboot code for bootargsd and associated components created for the Q4 Redfish and Q1 
-systems management deep dive demos.
+This code has been refactored from the old hms-netboot code for bootargsd and associated components created for the Q4 Redfish
+and Q1 systems management deep dive demos.
 
 ### BSS CT Testing
 
-This repository builds and publishes cray-bss-test image along with the service itself containing tests that verify BSS on a live Shasta systems. The tests are invoked via helm test.
-The version of the cray-bss-test image should match the version of the cray-bss image (vX.Y.Z (build metadata not withstanding)).
+In addition to the service itself, this repository builds and publishes cray-bss-test images containing tests that verify BSS
+on live Shasta systems. The tests are invoked via helm test as part of the Continuous Test (CT) framework during CSM installs
+and upgrades. The version of the cray-bss-test image (vX.Y.Z) should match the version of the cray-bss image being tested, both
+of which are specified in the helm chart for the service.


### PR DESCRIPTION
### Summary and Scope

- Update CT testing section of README for new Helm-based tests which replaces the former RPM-based tests.
- Assorted README cleanup.

### Issues and Related PRs

* Partially resolves CASMHMS-5608.

### Testing

- Rendered README updates and viewed them to verify that they look as expected.
- No testing performed due to documentation change only.

Was a fresh Install tested? N/A
Was an Upgrade tested? N/A
Was a Downgrade tested? N/A

### Risks and Mitigations

None, README change only.